### PR TITLE
Add Crypto Research Check-In app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log*
+.DS_Store
+data/data.db
+data/data.db-*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,67 @@
-# productv
+# Crypto Research Check-In
+
+Accountability app for Shamil and Halit to log daily crypto research. The project uses Node.js, Express, EJS templates, and SQLite (better-sqlite3).
+
+## Quick start
+
+```bash
+npm install
+npm run dev
+```
+
+The development server runs with `nodemon` on [http://localhost:3000](http://localhost:3000).
+
+## Login
+
+Only the names **Shamil** and **Halit** (case-insensitive) are accepted. Sessions are stored using encrypted cookies.
+
+## Features
+
+- Daily check-in with optional note (one per UTC day).
+- Research entry logging with title, summary, tickers, links, confidence, and minutes spent.
+- Public dashboard showing streaks, completion rates, heatmaps, and latest research.
+- Individual public profile pages with 90-day streak data and research history.
+- Audit logging for all check-in and research mutations.
+- `/api/stats` endpoint returning JSON streak and completion metrics for both users.
+
+## Database
+
+SQLite database lives at `./data/data.db`. Tables are created automatically at startup. To ensure the user rows exist you can run:
+
+```bash
+npm run seed
+```
+
+## Project structure
+
+```
+/package.json
+/server.js
+/db.js
+/utils/
+  date.js
+  sanitize.js
+/public/js/main.js
+/views/
+  layout.ejs
+  login.ejs
+  public.ejs
+  user.ejs
+  dashboard.ejs
+  /partials
+    flash.ejs
+    header.ejs
+/scripts/seed.js
+/data/
+```
+
+## Environment variables
+
+- `PORT` – server port (default `3000`)
+- `SESSION_SECRET` – overrides the cookie-session secret (recommended in production)
+
+## Notes
+
+- Tailwind CSS is loaded via CDN. No build step required.
+- All user-provided text is sanitized before rendering. URLs are linkified safely.
+- Dates and streak calculations use UTC day boundaries.

--- a/db.js
+++ b/db.js
@@ -1,0 +1,270 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import Database from 'better-sqlite3';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+import { todayUTC, rangeDaysBack, nowUTCISO } from './utils/date.js';
+
+dayjs.extend(utc);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const dbDir = path.join(__dirname, 'data');
+const dbPath = path.join(dbDir, 'data.db');
+
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
+const db = new Database(dbPath);
+db.pragma('journal_mode = WAL');
+
+export function init() {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS users (
+      id INTEGER PRIMARY KEY,
+      name TEXT UNIQUE NOT NULL CHECK(name IN ('Shamil','Halit')),
+      created_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS checkins (
+      id INTEGER PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      day TEXT NOT NULL,
+      note TEXT,
+      created_at TEXT NOT NULL,
+      UNIQUE(user_id, day),
+      FOREIGN KEY(user_id) REFERENCES users(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS research_entries (
+      id INTEGER PRIMARY KEY,
+      user_id INTEGER NOT NULL,
+      day TEXT NOT NULL,
+      title TEXT NOT NULL,
+      summary TEXT NOT NULL,
+      tickers TEXT,
+      links TEXT,
+      confidence INTEGER CHECK(confidence BETWEEN 1 AND 5),
+      minutes_spent INTEGER CHECK(minutes_spent BETWEEN 0 AND 1440),
+      created_at TEXT NOT NULL,
+      FOREIGN KEY(user_id) REFERENCES users(id)
+    );
+
+    CREATE TABLE IF NOT EXISTS audit_log (
+      id INTEGER PRIMARY KEY,
+      user_id INTEGER,
+      action TEXT NOT NULL,
+      entity_type TEXT,
+      entity_id INTEGER,
+      meta TEXT,
+      created_at TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_checkins_user_day ON checkins(user_id, day);
+    CREATE INDEX IF NOT EXISTS idx_re_user_day ON research_entries(user_id, day);
+    CREATE INDEX IF NOT EXISTS idx_re_day ON research_entries(day);
+  `);
+
+  const insertUser = db.prepare('INSERT OR IGNORE INTO users (name, created_at) VALUES (?, ?)');
+  const now = nowUTCISO();
+  insertUser.run('Shamil', now);
+  insertUser.run('Halit', now);
+}
+
+export function getUserByName(name) {
+  if (!name) return null;
+  return db.prepare('SELECT * FROM users WHERE lower(name) = lower(?) LIMIT 1').get(name.trim());
+}
+
+export function getAllUsers() {
+  return db.prepare('SELECT * FROM users ORDER BY name ASC').all();
+}
+
+export function upsertCheckin(userId, day, note) {
+  const now = nowUTCISO();
+  const stmt = db.prepare(`
+    INSERT INTO checkins (user_id, day, note, created_at)
+    VALUES (@userId, @day, @note, @now)
+    ON CONFLICT(user_id, day)
+    DO UPDATE SET note = excluded.note, created_at = excluded.created_at
+  `);
+  stmt.run({ userId, day, note, now });
+  return db.prepare('SELECT * FROM checkins WHERE user_id = ? AND day = ?').get(userId, day);
+}
+
+export function getCheckin(userId, day) {
+  return db.prepare('SELECT * FROM checkins WHERE user_id = ? AND day = ?').get(userId, day);
+}
+
+export function getLastActivity(userId) {
+  const row = db
+    .prepare(
+      `SELECT MAX(created_at) AS last_activity FROM (
+        SELECT created_at FROM checkins WHERE user_id = ?
+        UNION ALL
+        SELECT created_at FROM research_entries WHERE user_id = ?
+      )`
+    )
+    .get(userId, userId);
+  return row?.last_activity || null;
+}
+
+export function createResearch(userId, payload) {
+  const now = nowUTCISO();
+  const stmt = db.prepare(`
+    INSERT INTO research_entries (user_id, day, title, summary, tickers, links, confidence, minutes_spent, created_at)
+    VALUES (@userId, @day, @title, @summary, @tickers, @links, @confidence, @minutes, @now)
+  `);
+  const info = stmt.run({
+    userId,
+    day: payload.day,
+    title: payload.title,
+    summary: payload.summary,
+    tickers: payload.tickers,
+    links: payload.links,
+    confidence: payload.confidence,
+    minutes: payload.minutes_spent,
+    now,
+  });
+  return db.prepare('SELECT * FROM research_entries WHERE id = ?').get(info.lastInsertRowid);
+}
+
+export function updateResearch(id, userId, payload) {
+  const stmt = db.prepare(`
+    UPDATE research_entries
+    SET title = @title,
+        summary = @summary,
+        tickers = @tickers,
+        links = @links,
+        confidence = @confidence,
+        minutes_spent = @minutes
+    WHERE id = @id AND user_id = @userId
+  `);
+  const info = stmt.run({
+    id,
+    userId,
+    title: payload.title,
+    summary: payload.summary,
+    tickers: payload.tickers,
+    links: payload.links,
+    confidence: payload.confidence,
+    minutes: payload.minutes_spent,
+  });
+  return info.changes > 0;
+}
+
+export function deleteResearch(id, userId) {
+  const stmt = db.prepare('DELETE FROM research_entries WHERE id = ? AND user_id = ?');
+  const info = stmt.run(id, userId);
+  return info.changes > 0;
+}
+
+export function getResearchById(id) {
+  return db.prepare('SELECT * FROM research_entries WHERE id = ?').get(id);
+}
+
+export function getRecentResearch({ limit = 30, userName = null, days = null } = {}) {
+  const params = [];
+  let where = 'WHERE 1=1';
+  if (userName && userName !== 'All') {
+    where += ' AND lower(u.name) = lower(?)';
+    params.push(userName);
+  }
+  if (days) {
+    const startDay = rangeDaysBack(days, { newestFirst: false })[0];
+    where += ' AND re.day >= ?';
+    params.push(startDay);
+  }
+  const sql = `
+    SELECT re.*, u.name AS user_name
+    FROM research_entries re
+    JOIN users u ON re.user_id = u.id
+    ${where}
+    ORDER BY re.created_at DESC
+    LIMIT ?
+  `;
+  params.push(limit);
+  const rows = db.prepare(sql).all(...params);
+  return rows.map((row) => ({
+    ...row,
+    links: row.links ? JSON.parse(row.links) : [],
+  }));
+}
+
+export function getDailyPresenceMap(userId, daysBack) {
+  const map = new Map();
+  const range = rangeDaysBack(daysBack, { newestFirst: false });
+  range.forEach((day) => map.set(day, 0));
+  const startDay = range[0];
+  const rows = db
+    .prepare(
+      `SELECT day, COUNT(*) as count FROM (
+        SELECT day FROM checkins WHERE user_id = ? AND day >= ?
+        UNION ALL
+        SELECT day FROM research_entries WHERE user_id = ? AND day >= ?
+      )
+      GROUP BY day`
+    )
+    .all(userId, startDay, userId, startDay);
+  rows.forEach((row) => {
+    if (map.has(row.day)) {
+      map.set(row.day, Number(row.count));
+    }
+  });
+  return map;
+}
+
+export function computeStreak(userId) {
+  const rows = db
+    .prepare('SELECT day FROM checkins WHERE user_id = ? ORDER BY day DESC')
+    .all(userId);
+  const daySet = new Set(rows.map((r) => r.day));
+  let streak = 0;
+  let cursor = dayjs().utc();
+  while (daySet.has(cursor.format('YYYY-MM-DD'))) {
+    streak += 1;
+    cursor = cursor.subtract(1, 'day');
+  }
+  return streak;
+}
+
+export function computeCompletion(userId, windowDays) {
+  if (windowDays <= 0) {
+    return { totalDays: 0, completedDays: 0, percent: 0 };
+  }
+  const range = rangeDaysBack(windowDays, { newestFirst: false });
+  const startDay = range[0];
+  const row = db
+    .prepare('SELECT COUNT(*) as count FROM checkins WHERE user_id = ? AND day >= ?')
+    .get(userId, startDay);
+  const completedDays = row?.count ? Number(row.count) : 0;
+  return {
+    totalDays: windowDays,
+    completedDays,
+    percent: Math.round((completedDays / windowDays) * 100),
+  };
+}
+
+export function getResearchForUser(userId, days) {
+  const startDay = rangeDaysBack(days, { newestFirst: false })[0];
+  return db
+    .prepare(
+      `SELECT * FROM research_entries
+       WHERE user_id = ? AND day >= ?
+       ORDER BY created_at DESC`
+    )
+    .all(userId, startDay)
+    .map((row) => ({ ...row, links: row.links ? JSON.parse(row.links) : [] }));
+}
+
+export function writeAudit(userId, action, entityType, entityId, meta = {}) {
+  const now = nowUTCISO();
+  db.prepare(
+    `INSERT INTO audit_log (user_id, action, entity_type, entity_id, meta, created_at)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(userId, action, entityType, entityId, JSON.stringify(meta || {}), now);
+}
+
+export default db;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "crypto-research-check-in",
+  "version": "1.0.0",
+  "description": "Crypto Research Check-In accountability app",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "seed": "node scripts/seed.js"
+  },
+  "dependencies": {
+    "better-sqlite3": "^9.4.0",
+    "cookie-session": "^2.0.0",
+    "dayjs": "^1.11.10",
+    "ejs": "^3.1.9",
+    "express": "^4.18.2",
+    "morgan": "^1.10.0",
+    "xss": "^1.0.14"
+  },
+  "devDependencies": {
+    "nodemon": "^3.0.3"
+  }
+}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -1,0 +1,31 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('[data-auto-submit]').forEach((el) => {
+    el.addEventListener('change', () => {
+      if (el.form) el.form.submit();
+    });
+  });
+
+  document.querySelectorAll('.js-utc-time').forEach((el) => {
+    const iso = el.dataset.utc;
+    if (!iso) return;
+    const date = new Date(iso);
+    if (!Number.isNaN(date.getTime())) {
+      el.textContent = date.toLocaleString();
+    }
+  });
+
+  const addLinkBtn = document.querySelector('[data-add-link]');
+  const linksContainer = document.querySelector('[data-links-container]');
+  if (addLinkBtn && linksContainer) {
+    addLinkBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      const input = document.createElement('input');
+      input.type = 'url';
+      input.name = 'links';
+      input.placeholder = 'https://...';
+      input.className = 'mt-2 block w-full rounded border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500';
+      linksContainer.appendChild(input);
+      input.focus();
+    });
+  }
+});

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,0 +1,4 @@
+import { init } from '../db.js';
+
+init();
+console.log('Database initialized and users seeded.');

--- a/server.js
+++ b/server.js
@@ -1,0 +1,349 @@
+import express from 'express';
+import path from 'path';
+import morgan from 'morgan';
+import cookieSession from 'cookie-session';
+import {
+  init,
+  getUserByName,
+  getAllUsers,
+  upsertCheckin,
+  getCheckin,
+  getLastActivity,
+  createResearch,
+  updateResearch,
+  deleteResearch,
+  getResearchById,
+  getRecentResearch,
+  getDailyPresenceMap,
+  computeStreak,
+  computeCompletion,
+  getResearchForUser,
+  writeAudit,
+} from './db.js';
+import { todayUTC, nowUTCISO, formatDayShort } from './utils/date.js';
+import { escapeHtml, linkify } from './utils/sanitize.js';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+init();
+
+app.set('view engine', 'ejs');
+app.set('views', path.join(process.cwd(), 'views'));
+
+app.locals.escapeHtml = escapeHtml;
+app.locals.linkify = linkify;
+app.locals.formatDayShort = formatDayShort;
+
+app.use(morgan('dev'));
+app.use(express.urlencoded({ extended: true }));
+app.use(
+  cookieSession({
+    name: 'session',
+    keys: [process.env.SESSION_SECRET || 'dev-secret-crypto-checkin'],
+    maxAge: 30 * 24 * 60 * 60 * 1000,
+  })
+);
+app.use(express.static(path.join(process.cwd(), 'public')));
+
+app.use((req, res, next) => {
+  const render = res.render.bind(res);
+  res.render = (view, options = {}, callback) => {
+    if (typeof callback === 'function') {
+      return render(view, options, callback);
+    }
+    return render(view, options, (err, html) => {
+      if (err) {
+        throw err;
+      }
+      return render('layout', { ...options, body: html });
+    });
+  };
+
+  res.locals.currentUser = req.session?.user || null;
+  res.locals.flash = req.session?.flash || null;
+  if (req.session?.flash) {
+    delete req.session.flash;
+  }
+  next();
+});
+
+function setFlash(req, type, message) {
+  req.session.flash = { type, message };
+}
+
+function requireAuth(req, res, next) {
+  if (!req.session?.user) {
+    setFlash(req, 'error', 'Please log in.');
+    return res.redirect('/login');
+  }
+  return next();
+}
+
+function ownerOnly(req, res, next) {
+  const user = req.session?.user;
+  if (!user) {
+    setFlash(req, 'error', 'Unauthorized');
+    return res.redirect('/login');
+  }
+  const entryId = Number(req.params.id);
+  if (Number.isNaN(entryId)) {
+    setFlash(req, 'error', 'Invalid request.');
+    return res.redirect('/dashboard');
+  }
+  const entry = getResearchById(entryId);
+  if (!entry || entry.user_id !== user.id) {
+    setFlash(req, 'error', 'Not allowed.');
+    return res.redirect('/dashboard');
+  }
+  req.entry = entry;
+  return next();
+}
+
+app.get('/', (req, res) => {
+  res.redirect('/public');
+});
+
+app.get('/login', (req, res) => {
+  res.render('login', { title: 'Login' });
+});
+
+app.post('/login', (req, res) => {
+  const name = req.body.name?.trim();
+  const user = getUserByName(name);
+  if (!user) {
+    setFlash(req, 'error', 'Unable to log in with that name.');
+    return res.redirect('/login');
+  }
+  req.session.user = { id: user.id, name: user.name };
+  setFlash(req, 'success', `Welcome back, ${user.name}!`);
+  return res.redirect('/dashboard');
+});
+
+app.post('/logout', (req, res) => {
+  req.session = null;
+  res.redirect('/public');
+});
+
+app.get('/dashboard', requireAuth, (req, res) => {
+  const { user } = req.session;
+  const today = todayUTC();
+  const checkin = getCheckin(user.id, today);
+  const recentResearch = getResearchForUser(user.id, 7);
+  res.render('dashboard', {
+    title: 'Dashboard',
+    today,
+    checkin,
+    recentResearch,
+  });
+});
+
+function parseTickers(raw) {
+  if (!raw) return '';
+  return raw
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map((t) => t.toUpperCase())
+    .join(',');
+}
+
+function parseLinks(raw) {
+  if (!raw) return [];
+  let linksArray = [];
+  if (Array.isArray(raw)) {
+    linksArray = raw;
+  } else if (typeof raw === 'string') {
+    linksArray = raw.split(/[\n,]+/);
+  } else {
+    linksArray = [raw];
+  }
+  const clean = [];
+  linksArray.forEach((value) => {
+    const trimmed = value.trim();
+    if (!trimmed) return;
+    try {
+      const url = new URL(trimmed);
+      if (['http:', 'https:'].includes(url.protocol)) {
+        clean.push(url.toString());
+      }
+    } catch (err) {
+      // ignore bad URLs
+    }
+  });
+  return clean;
+}
+
+app.post('/checkin', requireAuth, (req, res) => {
+  const { user } = req.session;
+  const today = todayUTC();
+  const note = req.body.note?.toString().slice(0, 2000) || '';
+  const saved = upsertCheckin(user.id, today, note);
+  writeAudit(user.id, 'checkin.upsert', 'checkin', saved.id, { day: today });
+  setFlash(req, 'success', 'Check-in recorded.');
+  res.redirect('/dashboard');
+});
+
+app.post('/research', requireAuth, (req, res) => {
+  const { user } = req.session;
+  const today = todayUTC();
+  const {
+    title,
+    summary,
+    tickers,
+    confidence,
+    minutes_spent,
+    day = today,
+  } = req.body;
+  if (!title?.trim() || !summary?.trim()) {
+    setFlash(req, 'error', 'Title and summary are required.');
+    return res.redirect('/dashboard');
+  }
+  const parsed = {
+    day,
+    title: title.trim().slice(0, 255),
+    summary: summary.trim().slice(0, 5000),
+    tickers: parseTickers(tickers).slice(0, 255),
+    links: JSON.stringify(parseLinks(req.body.links)),
+    confidence: Math.min(5, Math.max(1, Number(confidence) || 3)),
+    minutes_spent: Math.min(1440, Math.max(0, Number(minutes_spent) || 0)),
+  };
+  const entry = createResearch(user.id, parsed);
+  writeAudit(user.id, 'research.create', 'research', entry.id, { day: parsed.day });
+  setFlash(req, 'success', 'Research entry added.');
+  res.redirect('/dashboard');
+});
+
+app.post('/research/:id/edit', requireAuth, ownerOnly, (req, res) => {
+  const { user } = req.session;
+  const entryId = Number(req.params.id);
+  const { title, summary, tickers, confidence, minutes_spent } = req.body;
+  if (!title?.trim() || !summary?.trim()) {
+    setFlash(req, 'error', 'Title and summary are required.');
+    return res.redirect('/dashboard');
+  }
+  const payload = {
+    title: title.trim().slice(0, 255),
+    summary: summary.trim().slice(0, 5000),
+    tickers: parseTickers(tickers).slice(0, 255),
+    links: JSON.stringify(parseLinks(req.body.links)),
+    confidence: Math.min(5, Math.max(1, Number(confidence) || 3)),
+    minutes_spent: Math.min(1440, Math.max(0, Number(minutes_spent) || 0)),
+  };
+  const success = updateResearch(entryId, user.id, payload);
+  if (success) {
+    writeAudit(user.id, 'research.edit', 'research', entryId, {});
+    setFlash(req, 'success', 'Research entry updated.');
+  } else {
+    setFlash(req, 'error', 'Unable to update entry.');
+  }
+  res.redirect('/dashboard');
+});
+
+app.post('/research/:id/delete', requireAuth, ownerOnly, (req, res) => {
+  const { user } = req.session;
+  const entryId = Number(req.params.id);
+  const success = deleteResearch(entryId, user.id);
+  if (success) {
+    writeAudit(user.id, 'research.delete', 'research', entryId, {});
+    setFlash(req, 'success', 'Entry removed.');
+  } else {
+    setFlash(req, 'error', 'Unable to remove entry.');
+  }
+  res.redirect('/dashboard');
+});
+
+function buildHeatmap(map) {
+  return Array.from(map.entries()).map(([day, count]) => ({ day, count }));
+}
+
+function userStats(user) {
+  const today = todayUTC();
+  const hasToday = Boolean(getCheckin(user.id, today));
+  const lastActivity = getLastActivity(user.id);
+  const streak = computeStreak(user.id);
+  const completion30 = computeCompletion(user.id, 30);
+  const completion90 = computeCompletion(user.id, 90);
+  const completion7 = computeCompletion(user.id, 7);
+  const heatmap = buildHeatmap(getDailyPresenceMap(user.id, 90));
+  return {
+    user,
+    hasToday,
+    lastActivity,
+    streak,
+    completion30,
+    completion90,
+    completion7,
+    heatmap,
+  };
+}
+
+app.get('/public', (req, res) => {
+  const users = getAllUsers();
+  const stats = users.map(userStats);
+  const filterUser = req.query.user || 'All';
+  const range = Number(req.query.range) || 30;
+  const rangeDays = [7, 30, 90].includes(range) ? range : 30;
+  const feed = getRecentResearch({ limit: 30, userName: filterUser, days: rangeDays });
+  res.render('public', {
+    title: 'Public Dashboard',
+    stats,
+    feed,
+    filterUser,
+    rangeDays,
+  });
+});
+
+app.get('/u/:name', (req, res) => {
+  const user = getUserByName(req.params.name);
+  if (!user) {
+    return res.status(404).render('public', {
+      title: 'Not found',
+      stats: [],
+      feed: [],
+      filterUser: 'All',
+      rangeDays: 30,
+      error: 'User not found',
+    });
+  }
+  const stats = userStats(user);
+  const feed = getRecentResearch({ limit: 30, userName: user.name, days: 90 });
+  res.render('user', {
+    title: `${user.name} Profile`,
+    stats,
+    feed,
+  });
+});
+
+app.get('/api/stats', (req, res) => {
+  const users = getAllUsers();
+  const data = users.map((user) => {
+    const streak = computeStreak(user.id);
+    const completion7 = computeCompletion(user.id, 7);
+    const completion30 = computeCompletion(user.id, 30);
+    const completion90 = computeCompletion(user.id, 90);
+    return {
+      name: user.name,
+      streak,
+      completion7,
+      completion30,
+      completion90,
+    };
+  });
+  res.json({ generated_at: nowUTCISO(), data });
+});
+
+app.use((req, res) => {
+  res.status(404).render('public', {
+    title: 'Not found',
+    stats: [],
+    feed: [],
+    filterUser: 'All',
+    rangeDays: 30,
+    error: 'Page not found',
+  });
+});
+
+app.listen(PORT, () => {
+  console.log(`Crypto Research Check-In running on http://localhost:${PORT}`);
+});

--- a/utils/date.js
+++ b/utils/date.js
@@ -1,0 +1,50 @@
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc.js';
+
+dayjs.extend(utc);
+
+/**
+ * Return current UTC day string (YYYY-MM-DD)
+ */
+export function todayUTC() {
+  return dayjs().utc().format('YYYY-MM-DD');
+}
+
+/**
+ * Convert any date-like input to a UTC day string.
+ * @param {string|Date|number} input
+ */
+export function toUTCDay(input) {
+  return dayjs(input).utc().format('YYYY-MM-DD');
+}
+
+/**
+ * Return an array of day strings counting backwards from today.
+ * @param {number} n number of days
+ * @param {boolean} newestFirst whether newest first (default false -> oldest first)
+ */
+export function rangeDaysBack(n, { newestFirst = false } = {}) {
+  const days = [];
+  const today = dayjs().utc();
+  for (let i = n - 1; i >= 0; i -= 1) {
+    days.push(today.subtract(i, 'day').format('YYYY-MM-DD'));
+  }
+  if (newestFirst) {
+    return days.slice().reverse();
+  }
+  return days;
+}
+
+/**
+ * Return ISO timestamp string for now in UTC.
+ */
+export function nowUTCISO() {
+  return dayjs().utc().toISOString();
+}
+
+/**
+ * Convert a UTC day string to a human readable format (e.g., Apr 5).
+ */
+export function formatDayShort(day) {
+  return dayjs.utc(day).format('MMM D');
+}

--- a/utils/sanitize.js
+++ b/utils/sanitize.js
@@ -1,0 +1,32 @@
+import xss from 'xss';
+
+const whiteList = {};
+const xssOptions = {
+  whiteList,
+  stripIgnoreTag: true,
+};
+
+/** Escape HTML special characters. */
+export function escapeHtml(str = '') {
+  return xss(str, xssOptions);
+}
+
+const urlRegex = /((https?:\/\/)[^\s<]+)/gi;
+
+/**
+ * Convert plain URLs in text into safe clickable links.
+ * The input is first escaped to ensure no HTML sneaks through.
+ */
+export function linkify(text = '') {
+  const escaped = escapeHtml(text);
+  return escaped.replace(urlRegex, (match) => {
+    const url = match.trim();
+    try {
+      const parsed = new URL(url);
+      const safeHref = escapeHtml(parsed.href);
+      return `<a href="${safeHref}" class="text-blue-500 underline" target="_blank" rel="noopener noreferrer">${safeHref}</a>`;
+    } catch (err) {
+      return escapeHtml(url);
+    }
+  });
+}

--- a/views/dashboard.ejs
+++ b/views/dashboard.ejs
@@ -1,0 +1,170 @@
+<section class="space-y-10">
+  <div class="rounded border border-slate-800 bg-slate-900/60 p-6">
+    <h1 class="text-3xl font-semibold text-white">Welcome, <%= currentUser.name %></h1>
+    <p class="mt-2 text-sm text-slate-400">Stay accountable by checking in and logging your research daily.</p>
+  </div>
+
+  <div class="grid gap-6 lg:grid-cols-2">
+    <section class="rounded border border-slate-800 bg-slate-900/60 p-6">
+      <h2 class="text-xl font-semibold text-white">Today</h2>
+      <% if (checkin) { %>
+        <p class="mt-2 text-sm text-slate-300">Checked in at <span class="js-utc-time" data-utc="<%= checkin.created_at %>">Loading…</span></p>
+      <% } else { %>
+        <p class="mt-2 text-sm text-slate-300">You have not checked in yet today.</p>
+      <% } %>
+      <form method="POST" action="/checkin" class="mt-4 space-y-4">
+        <div>
+          <label for="note" class="block text-sm font-medium text-slate-300">Note (optional)</label>
+          <textarea
+            id="note"
+            name="note"
+            rows="3"
+            class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            placeholder="Key focus for today"
+          ><%= checkin?.note ? escapeHtml(checkin.note) : '' %></textarea>
+        </div>
+        <button type="submit" class="w-full rounded bg-emerald-500 px-3 py-2 text-sm font-semibold text-emerald-950 transition hover:bg-emerald-400">
+          <%= checkin ? 'Update check-in' : 'Check In' %>
+        </button>
+      </form>
+    </section>
+
+    <section class="rounded border border-slate-800 bg-slate-900/60 p-6">
+      <h2 class="text-xl font-semibold text-white">Add Research</h2>
+      <form method="POST" action="/research" class="mt-4 space-y-4">
+        <input type="hidden" name="day" value="<%= today %>" />
+        <div>
+          <label for="title" class="block text-sm font-medium text-slate-300">Title</label>
+          <input
+            type="text"
+            id="title"
+            name="title"
+            required
+            class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label for="summary" class="block text-sm font-medium text-slate-300">Summary</label>
+          <textarea
+            id="summary"
+            name="summary"
+            required
+            rows="4"
+            class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            placeholder="Key findings, hypotheses, questions..."
+          ></textarea>
+        </div>
+        <div>
+          <label for="tickers" class="block text-sm font-medium text-slate-300">Tickers</label>
+          <input
+            type="text"
+            id="tickers"
+            name="tickers"
+            placeholder="BTC,ETH"
+            class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+          />
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-slate-300">Links</label>
+          <div data-links-container>
+            <input
+              type="url"
+              name="links"
+              placeholder="https://..."
+              class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </div>
+          <button type="button" data-add-link class="mt-2 text-xs font-semibold text-indigo-300 hover:text-indigo-200">+ Add another link</button>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <label class="block text-sm font-medium text-slate-300">Confidence
+            <select name="confidence" class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500">
+              <% for (let i = 1; i <= 5; i += 1) { %>
+                <option value="<%= i %>"><%= i %></option>
+              <% } %>
+            </select>
+          </label>
+          <label class="block text-sm font-medium text-slate-300">Minutes spent
+            <input
+              type="number"
+              name="minutes_spent"
+              min="0"
+              max="1440"
+              value="0"
+              class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            />
+          </label>
+        </div>
+        <button type="submit" class="w-full rounded bg-indigo-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400">Save entry</button>
+      </form>
+    </section>
+  </div>
+
+  <section class="rounded border border-slate-800 bg-slate-900/60 p-6">
+    <h2 class="text-xl font-semibold text-white">Your last 7 days</h2>
+    <p class="mt-2 text-sm text-slate-400">Quick access to edit or remove recent research.</p>
+    <div class="mt-4 space-y-4">
+      <% if (!recentResearch.length) { %>
+        <p class="text-sm text-slate-400">No entries logged in the last 7 days.</p>
+      <% } %>
+      <% recentResearch.forEach((entry) => { %>
+        <details class="rounded border border-slate-800 bg-slate-950/60 p-4">
+          <summary class="cursor-pointer text-sm text-white">
+            <span class="font-semibold"><%= escapeHtml(entry.title) %></span>
+            <span class="ml-2 text-xs text-slate-400"><%= entry.day %> · <%= entry.minutes_spent ?? 0 %> min · Confidence <%= entry.confidence || 0 %>/5</span>
+          </summary>
+          <div class="mt-4 space-y-4 text-sm text-slate-200">
+            <div class="leading-relaxed text-slate-200"><%- linkify(entry.summary || '').replace(/\n/g, '<br/>') %></div>
+            <% if (entry.tickers) { %>
+              <div class="flex flex-wrap gap-2 text-xs">
+                <% entry.tickers.split(',').filter(Boolean).forEach((ticker) => { %>
+                  <span class="rounded-full bg-slate-800 px-2 py-1 font-semibold text-indigo-200"><%= ticker %></span>
+                <% }) %>
+              </div>
+            <% } %>
+            <% if (entry.links && entry.links.length) { %>
+              <div class="flex flex-wrap gap-2 text-xs text-indigo-300">
+                <% entry.links.forEach((url) => { %>
+                  <a href="<%= url %>" target="_blank" rel="noopener noreferrer" class="truncate rounded bg-slate-800 px-2 py-1 hover:bg-slate-700"><%= url %></a>
+                <% }) %>
+              </div>
+            <% } %>
+            <form method="POST" action="/research/<%= entry.id %>/edit" class="space-y-3">
+              <div>
+                <label class="block text-xs font-medium text-slate-400">Title</label>
+                <input type="text" name="title" value="<%= escapeHtml(entry.title) %>" required class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white" />
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-slate-400">Summary</label>
+                <textarea name="summary" rows="3" required class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white"><%= escapeHtml(entry.summary) %></textarea>
+              </div>
+              <div class="grid gap-3 sm:grid-cols-3">
+                <label class="block text-xs font-medium text-slate-400">Tickers
+                  <input type="text" name="tickers" value="<%= escapeHtml(entry.tickers || '') %>" class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white" />
+                </label>
+                <label class="block text-xs font-medium text-slate-400">Confidence
+                  <select name="confidence" class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-2 py-2 text-sm text-white">
+                    <% for (let i = 1; i <= 5; i += 1) { %>
+                      <option value="<%= i %>" <%= entry.confidence === i ? 'selected' : '' %>><%= i %></option>
+                    <% } %>
+                  </select>
+                </label>
+                <label class="block text-xs font-medium text-slate-400">Minutes
+                  <input type="number" name="minutes_spent" min="0" max="1440" value="<%= entry.minutes_spent ?? 0 %>" class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white" />
+                </label>
+              </div>
+              <div>
+                <label class="block text-xs font-medium text-slate-400">Links (comma separated)</label>
+                <input type="text" name="links" value="<%= entry.links && entry.links.length ? escapeHtml(entry.links.join(', ')) : '' %>" class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white" />
+              </div>
+              <button type="submit" class="rounded bg-indigo-500 px-3 py-2 text-xs font-semibold text-white hover:bg-indigo-400">Save changes</button>
+            </form>
+            <form method="POST" action="/research/<%= entry.id %>/delete" class="inline">
+              <button type="submit" class="mt-2 rounded bg-rose-500 px-3 py-2 text-xs font-semibold text-rose-100 hover:bg-rose-400">Delete</button>
+            </form>
+          </div>
+        </details>
+      <% }) %>
+    </div>
+  </section>
+</section>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en" class="h-full">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title><%= title ? title + ' · Crypto Research Check-In' : 'Crypto Research Check-In' %></title>
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="min-h-full bg-slate-950 text-slate-100">
+    <div class="min-h-full">
+      <%- include('partials/header') %>
+      <main class="mx-auto w-full max-w-6xl px-4 py-8">
+        <%- include('partials/flash') %>
+        <%- body %>
+      </main>
+    </div>
+    <script src="/js/main.js" defer></script>
+  </body>
+</html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -1,0 +1,20 @@
+<section class="mx-auto max-w-md rounded border border-slate-800 bg-slate-900/60 p-6 shadow-lg">
+  <h1 class="text-2xl font-semibold text-white">Login</h1>
+  <p class="mt-2 text-sm text-slate-400">Enter your name to access your dashboard.</p>
+  <form method="POST" action="/login" class="mt-6 space-y-4">
+    <div>
+      <label for="name" class="block text-sm font-medium text-slate-300">Name</label>
+      <input
+        type="text"
+        id="name"
+        name="name"
+        placeholder="Shamil or Halit"
+        required
+        class="mt-1 w-full rounded border border-slate-700 bg-slate-950 px-3 py-2 text-white focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+      />
+    </div>
+    <button type="submit" class="w-full rounded bg-indigo-500 px-3 py-2 text-sm font-semibold text-white transition hover:bg-indigo-400">
+      Log In
+    </button>
+  </form>
+</section>

--- a/views/partials/flash.ejs
+++ b/views/partials/flash.ejs
@@ -1,0 +1,8 @@
+<% if (flash) { %>
+  <div class="mb-6 rounded border border-slate-700 bg-slate-900 px-4 py-3 text-sm text-slate-200">
+    <span class="font-semibold uppercase tracking-wide <%= flash.type === 'error' ? 'text-rose-300' : 'text-emerald-300' %>">
+      <%= flash.type === 'error' ? 'Error' : 'Info' %>
+    </span>
+    <div class="mt-1"><%= escapeHtml(flash.message) %></div>
+  </div>
+<% } %>

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,0 +1,19 @@
+<header class="border-b border-slate-800 bg-slate-900/80 backdrop-blur">
+  <div class="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+    <a href="/public" class="text-lg font-semibold tracking-tight text-indigo-300">Crypto Research Check-In</a>
+    <nav class="flex items-center gap-4 text-sm text-slate-300">
+      <a href="/public" class="hover:text-white">Public</a>
+      <% if (currentUser) { %>
+        <a href="/dashboard" class="hover:text-white">Dashboard</a>
+      <% } %>
+      <% if (currentUser) { %>
+        <form method="POST" action="/logout" class="flex items-center gap-2">
+          <span class="text-xs text-slate-400">Logged in as <strong class="text-white"><%= currentUser.name %></strong></span>
+          <button type="submit" class="rounded bg-slate-800 px-3 py-1 text-xs font-semibold text-slate-200 transition hover:bg-slate-700">Logout</button>
+        </form>
+      <% } else { %>
+        <a href="/login" class="rounded bg-indigo-500 px-3 py-1 text-xs font-semibold text-white transition hover:bg-indigo-400">Login</a>
+      <% } %>
+    </nav>
+  </div>
+</header>

--- a/views/public.ejs
+++ b/views/public.ejs
@@ -1,0 +1,152 @@
+<section class="space-y-10">
+  <% if (typeof error !== 'undefined' && error) { %>
+    <div class="rounded border border-rose-500/30 bg-rose-500/10 px-4 py-3 text-sm text-rose-200"><%= escapeHtml(error) %></div>
+  <% } %>
+
+  <div>
+    <h1 class="text-3xl font-semibold text-white">Public Dashboard</h1>
+    <p class="mt-2 text-sm text-slate-400">Track Shamil and Halit’s daily crypto research habits.</p>
+  </div>
+
+  <div>
+    <h2 class="text-xl font-semibold text-white">Today at a glance</h2>
+    <div class="mt-4 grid gap-4 sm:grid-cols-2">
+      <% stats.forEach(({ user, hasToday, lastActivity }) => { %>
+        <div class="rounded border border-slate-800 bg-slate-900/60 p-4">
+          <div class="flex items-center justify-between">
+            <div>
+              <p class="text-lg font-semibold text-white"><%= user.name %></p>
+              <p class="text-xs text-slate-400">Last activity: <span class="js-utc-time" data-utc="<%= lastActivity || '' %>"><%= lastActivity ? 'Loading…' : 'No activity yet' %></span></p>
+            </div>
+            <span class="h-3 w-3 rounded-full <%= hasToday ? 'bg-emerald-400 shadow-[0_0_10px_#34d399]' : 'bg-slate-600' %>"></span>
+          </div>
+          <p class="mt-4 text-sm text-slate-300">
+            <% if (hasToday) { %>
+              Checked in today
+            <% } else { %>
+              Waiting for today’s check-in
+            <% } %>
+          </p>
+        </div>
+      <% }) %>
+    </div>
+  </div>
+
+  <div>
+    <h2 class="text-xl font-semibold text-white">Streak & Consistency</h2>
+    <div class="mt-4 grid gap-4 sm:grid-cols-2">
+      <% stats.forEach(({ user, streak, completion30, completion90, completion7 }) => { %>
+        <div class="rounded border border-slate-800 bg-slate-900/60 p-4">
+          <h3 class="text-lg font-semibold text-white"><%= user.name %></h3>
+          <dl class="mt-3 space-y-3 text-sm text-slate-300">
+            <div class="flex items-center justify-between">
+              <dt>Current streak</dt>
+              <dd class="font-semibold text-indigo-300"><%= streak %> day<%= streak === 1 ? '' : 's' %></dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Past 7 days</dt>
+              <dd><%= completion7.completedDays %>/<%= completion7.totalDays %> (<%= completion7.percent %>%)</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Past 30 days</dt>
+              <dd><%= completion30.completedDays %>/<%= completion30.totalDays %> (<%= completion30.percent %>%)</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt>Past 90 days</dt>
+              <dd><%= completion90.completedDays %>/<%= completion90.totalDays %> (<%= completion90.percent %>%)</dd>
+            </div>
+          </dl>
+        </div>
+      <% }) %>
+    </div>
+  </div>
+
+  <div>
+    <h2 class="text-xl font-semibold text-white">90-day heatmap</h2>
+    <div class="mt-4 space-y-6">
+      <% stats.forEach(({ user, heatmap }) => { %>
+        <div class="rounded border border-slate-800 bg-slate-900/60 p-4">
+          <div class="flex items-center justify-between text-sm text-slate-300">
+            <h3 class="text-lg font-semibold text-white"><%= user.name %></h3>
+            <a href="/u/<%= encodeURIComponent(user.name) %>" class="text-xs text-indigo-300 hover:text-indigo-200">View profile →</a>
+          </div>
+          <div class="mt-4 grid grid-cols-13 gap-1">
+            <% heatmap.forEach(({ day, count }) => { %>
+              <% const level = count === 0 ? 'bg-slate-800' : count === 1 ? 'bg-emerald-700/70' : 'bg-emerald-400'; %>
+              <div
+                class="h-4 w-4 rounded-sm <%= level %>"
+                title="<%= formatDayShort(day) %>: <%= count %> activity"
+              ></div>
+            <% }) %>
+          </div>
+          <div class="mt-2 text-xs text-slate-500">Latest 90 days</div>
+        </div>
+      <% }) %>
+    </div>
+  </div>
+
+  <div>
+    <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h2 class="text-xl font-semibold text-white">Recent Research</h2>
+        <p class="text-sm text-slate-400">Latest 30 entries from both users.</p>
+      </div>
+      <form method="GET" action="/public" class="flex flex-wrap gap-2 text-sm text-slate-300">
+        <label class="flex items-center gap-2">
+          User
+          <select name="user" class="rounded border border-slate-700 bg-slate-950 px-2 py-1" data-auto-submit>
+            <option value="All" <%= filterUser === 'All' ? 'selected' : '' %>>All</option>
+            <option value="Shamil" <%= filterUser === 'Shamil' ? 'selected' : '' %>>Shamil</option>
+            <option value="Halit" <%= filterUser === 'Halit' ? 'selected' : '' %>>Halit</option>
+          </select>
+        </label>
+        <label class="flex items-center gap-2">
+          Range
+          <select name="range" class="rounded border border-slate-700 bg-slate-950 px-2 py-1" data-auto-submit>
+            <option value="7" <%= rangeDays === 7 ? 'selected' : '' %>>7d</option>
+            <option value="30" <%= rangeDays === 30 ? 'selected' : '' %>>30d</option>
+            <option value="90" <%= rangeDays === 90 ? 'selected' : '' %>>90d</option>
+          </select>
+        </label>
+      </form>
+    </div>
+
+    <div class="mt-4 space-y-4">
+      <% if (!feed.length) { %>
+        <p class="text-sm text-slate-400">No research logged for this window.</p>
+      <% } %>
+      <% feed.forEach((entry) => { %>
+        <article class="rounded border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-200">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-lg font-semibold text-white"><%= escapeHtml(entry.title) %></h3>
+              <p class="text-xs text-slate-400">By <span class="font-semibold text-indigo-300"><%= entry.user_name %></span> · <span><%= entry.day %></span></p>
+            </div>
+            <div class="text-xs text-slate-400">
+              <span>Minutes: <%= entry.minutes_spent ?? 0 %></span>
+              <span class="ml-3">Confidence: <%= entry.confidence || 0 %>/5</span>
+            </div>
+          </div>
+          <div class="mt-3 space-y-2">
+            <div class="leading-relaxed text-slate-200"><%- linkify(entry.summary || '').replace(/\n/g, '<br/>') %></div>
+            <% if (entry.tickers) { %>
+              <div class="flex flex-wrap gap-2 text-xs">
+                <% entry.tickers.split(',').filter(Boolean).forEach((ticker) => { %>
+                  <span class="rounded-full bg-slate-800 px-2 py-1 font-semibold text-indigo-200"><%= ticker %></span>
+                <% }) %>
+              </div>
+            <% } %>
+            <% if (entry.links && entry.links.length) { %>
+              <div class="flex flex-wrap gap-2 text-xs text-indigo-300">
+                <% entry.links.forEach((url) => { %>
+                  <a href="<%= url %>" target="_blank" rel="noopener noreferrer" class="truncate rounded bg-slate-800 px-2 py-1 hover:bg-slate-700"><%= url %></a>
+                <% }) %>
+              </div>
+            <% } %>
+          </div>
+          <div class="mt-3 text-xs text-slate-500">Logged <span class="js-utc-time" data-utc="<%= entry.created_at %>">Loading…</span></div>
+        </article>
+      <% }) %>
+    </div>
+  </div>
+</section>

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -1,0 +1,71 @@
+<section class="space-y-10">
+  <div class="rounded border border-slate-800 bg-slate-900/60 p-6">
+    <h1 class="text-3xl font-semibold text-white"><%= stats.user.name %></h1>
+    <p class="mt-2 text-sm text-slate-400">Current streak: <span class="font-semibold text-indigo-300"><%= stats.streak %> day<%= stats.streak === 1 ? '' : 's' %></span></p>
+    <div class="mt-3 grid gap-4 sm:grid-cols-3">
+      <div class="rounded border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-300">
+        <p class="text-xs uppercase text-slate-400">Last 7 days</p>
+        <p class="mt-1 text-lg font-semibold text-white"><%= stats.completion7.completedDays %>/<%= stats.completion7.totalDays %> days</p>
+        <p class="text-xs text-slate-500"><%= stats.completion7.percent %>% completion</p>
+      </div>
+      <div class="rounded border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-300">
+        <p class="text-xs uppercase text-slate-400">Last 30 days</p>
+        <p class="mt-1 text-lg font-semibold text-white"><%= stats.completion30.completedDays %>/<%= stats.completion30.totalDays %> days</p>
+        <p class="text-xs text-slate-500"><%= stats.completion30.percent %>% completion</p>
+      </div>
+      <div class="rounded border border-slate-800 bg-slate-950/60 p-4 text-sm text-slate-300">
+        <p class="text-xs uppercase text-slate-400">Last 90 days</p>
+        <p class="mt-1 text-lg font-semibold text-white"><%= stats.completion90.completedDays %>/<%= stats.completion90.totalDays %> days</p>
+        <p class="text-xs text-slate-500"><%= stats.completion90.percent %>% completion</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="rounded border border-slate-800 bg-slate-900/60 p-6">
+    <h2 class="text-xl font-semibold text-white">90-day heatmap</h2>
+    <div class="mt-4 grid grid-cols-13 gap-1">
+      <% stats.heatmap.forEach(({ day, count }) => { %>
+        <% const level = count === 0 ? 'bg-slate-800' : count === 1 ? 'bg-emerald-700/70' : 'bg-emerald-400'; %>
+        <div class="h-4 w-4 rounded-sm <%= level %>" title="<%= formatDayShort(day) %>: <%= count %> activity"></div>
+      <% }) %>
+    </div>
+    <p class="mt-2 text-xs text-slate-500">Latest 90 days</p>
+  </div>
+
+  <div>
+    <h2 class="text-xl font-semibold text-white">Recent Research</h2>
+    <div class="mt-4 space-y-4">
+      <% if (!feed.length) { %>
+        <p class="text-sm text-slate-400">No research entries yet.</p>
+      <% } %>
+      <% feed.forEach((entry) => { %>
+        <article class="rounded border border-slate-800 bg-slate-900/60 p-4 text-sm text-slate-200">
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h3 class="text-lg font-semibold text-white"><%= escapeHtml(entry.title) %></h3>
+              <p class="text-xs text-slate-400"><%= entry.day %> · Confidence <%= entry.confidence || 0 %>/5 · <%= entry.minutes_spent ?? 0 %> minutes</p>
+            </div>
+          </div>
+          <div class="mt-3 space-y-2">
+            <div class="leading-relaxed text-slate-200"><%- linkify(entry.summary || '').replace(/\n/g, '<br/>') %></div>
+            <% if (entry.tickers) { %>
+              <div class="flex flex-wrap gap-2 text-xs">
+                <% entry.tickers.split(',').filter(Boolean).forEach((ticker) => { %>
+                  <span class="rounded-full bg-slate-800 px-2 py-1 font-semibold text-indigo-200"><%= ticker %></span>
+                <% }) %>
+              </div>
+            <% } %>
+            <% if (entry.links && entry.links.length) { %>
+              <div class="flex flex-wrap gap-2 text-xs text-indigo-300">
+                <% entry.links.forEach((url) => { %>
+                  <a href="<%= url %>" target="_blank" rel="noopener noreferrer" class="truncate rounded bg-slate-800 px-2 py-1 hover:bg-slate-700"><%= url %></a>
+                <% }) %>
+              </div>
+            <% } %>
+          </div>
+          <div class="mt-3 text-xs text-slate-500">Logged <span class="js-utc-time" data-utc="<%= entry.created_at %>">Loading…</span></div>
+        </article>
+      <% }) %>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
## Summary
- scaffold a Node.js + Express app for the Crypto Research Check-In accountability tool with SQLite persistence and EJS views
- implement public dashboards, user profiles, name-only authentication, daily check-ins, research logging, and audit logging utilities
- add Tailwind-styled interfaces, sanitization helpers, and front-end scripts for filters, local time display, and dynamic link fields

## Testing
- npm run seed
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68d3965e207c8327ba333f910caa5f2a