### PR TITLE
Fix heatmap grid layout

### DIFF
--- a/views/public.ejs
+++ b/views/public.ejs
@@ -70,7 +70,7 @@
             <h3 class="text-lg font-semibold text-white"><%= user.name %></h3>
             <a href="/u/<%= encodeURIComponent(user.name) %>" class="text-xs text-indigo-300 hover:text-indigo-200">View profile →</a>
           </div>
-          <div class="mt-4 grid grid-cols-13 gap-1">
+          <div class="mt-4 grid grid-cols-[repeat(13,_minmax(0,_1fr))] grid-rows-7 grid-flow-col gap-1">
             <% heatmap.forEach(({ day, count }) => { %>
               <% const level = count === 0 ? 'bg-slate-800' : count === 1 ? 'bg-emerald-700/70' : 'bg-emerald-400'; %>
               <div

--- a/views/user.ejs
+++ b/views/user.ejs
@@ -23,7 +23,7 @@
 
   <div class="rounded border border-slate-800 bg-slate-900/60 p-6">
     <h2 class="text-xl font-semibold text-white">90-day heatmap</h2>
-    <div class="mt-4 grid grid-cols-13 gap-1">
+    <div class="mt-4 grid grid-cols-[repeat(13,_minmax(0,_1fr))] grid-rows-7 grid-flow-col gap-1">
       <% stats.heatmap.forEach(({ day, count }) => { %>
         <% const level = count === 0 ? 'bg-slate-800' : count === 1 ? 'bg-emerald-700/70' : 'bg-emerald-400'; %>
         <div class="h-4 w-4 rounded-sm <%= level %>" title="<%= formatDayShort(day) %>: <%= count %> activity"></div>


### PR DESCRIPTION
## Summary
- replace the unsupported `grid-cols-13` utility in the heatmap templates with Tailwind's arbitrary value syntax
- ensure the contribution grids use a 13-column, 7-row layout so 90 days render in a dense matrix

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6f14e4b2c8327889aa8068fec880f